### PR TITLE
Trivial typo fix to comment

### DIFF
--- a/CMakeScripts/JoinPaths.cmake
+++ b/CMakeScripts/JoinPaths.cmake
@@ -1,5 +1,5 @@
 # This module provides function for joining paths
-# known from from most languages
+# known from most languages
 #
 # SPDX-License-Identifier: (MIT OR CC0-1.0)
 # Copyright 2020 Jan Tojnar


### PR DESCRIPTION
I got a [comment about a typo](https://github.com/raysan5/raylib/pull/1383#discussion_r494538125) for JoinPaths that I copy/pasted.
Thought I should fix it at the source.