### PR TITLE
JoinPaths: Prepend ${prefix} when dir is inside the prefix.

### DIFF
--- a/CMakeScripts/JoinPaths.cmake
+++ b/CMakeScripts/JoinPaths.cmake
@@ -1,4 +1,4 @@
-# This module provides function for joining paths
+# This module provides functions for joining paths
 # known from most languages
 #
 # SPDX-License-Identifier: (MIT OR CC0-1.0)
@@ -16,6 +16,23 @@ function(join_paths joined_path first_path_segment)
                 set(temp_path "${current_segment}")
             else()
                 set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()
+
+function(join_paths_for_pkgconfig joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            string(REGEX REPLACE "^${CMAKE_INSTALL_PREFIX}/?" "" new_segment "${current_segment}")
+            if(NOT ("${new_segment}" STREQUAL ""))
+                if(NOT IS_ABSOLUTE "${current_segment}" OR NOT "${current_segment}" MATCHES "^${new_segment}$")
+                    set(temp_path "${temp_path}/${new_segment}")
+                else()
+                    set(temp_path "${current_segment}")
+                endif()
             endif()
         endif()
     endforeach()


### PR DESCRIPTION
Note I started off with the copy merged in jsoncpp.

https://github.com/open-source-parsers/jsoncpp/commit/5be07bdc5e2d5b7715ecbc73749af3e625674dcb

At least on unix systems there are ~three~ four cases for generating a pkgconfig file with cmake.

* `CMAKE_INSTALL_<dir>` is relative and should have `${prefix}` prepended.
* `CMAKE_INSTALL_<dir>` is absolute and not inside `CMAKE_INSTALL_PREFIX`, it should be used as is.
* `CMAKE_INSTALL_<dir>` is absolute, but it is still inside of `CMAKE_INSTALL_PREFIX`, it should have `${prefix}` prepended.
* `CMAKE_INSTALL_<dir>` is the same as `CMAKE_INSTALL_PREFIX` and only `${prefix}` should be used.

This fixes the third and fourth cases.

Also there is a currently open PR for FAudio with this.

https://github.com/FNA-XNA/FAudio/pull/228